### PR TITLE
WDP200101-3

### DIFF
--- a/src/components/common/FeatureBox/FeatureBox.js
+++ b/src/components/common/FeatureBox/FeatureBox.js
@@ -7,12 +7,14 @@ import styles from './FeatureBox.module.scss';
 
 const FeatureBox = ({ active, icon, children }) => (
   <div className={styles.root + (active ? ' ' + styles.active : '')}>
-    {icon && (
-      <div className={styles.iconWrapper}>
-        <FontAwesomeIcon className={styles.icon} icon={icon} />
-      </div>
-    )}
-    <div className={styles.content}>{children}</div>
+    <a href='#'>
+      {icon && (
+        <div className={styles.iconWrapper}>
+          <FontAwesomeIcon className={styles.icon} icon={icon} />
+        </div>
+      )}
+      <div className={styles.content}>{children}</div>
+    </a>
   </div>
 );
 

--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -5,6 +5,10 @@
   text-align: center;
   margin-top: 40px;
 
+  a {
+    text-decoration: none;
+  }
+
   .iconWrapper {
     height: 60px;
     transform: translateY(-50%);
@@ -57,11 +61,12 @@
       margin: 0;
     }
 
-    p {
-    }
+    // p {
+    // }
   }
 
-  &.active {
+  &.active,
+  &:hover {
     .iconWrapper {
       color: $feature-box-icon-active;
 

--- a/src/components/features/FeatureBoxes/FeatureBoxes.js
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.js
@@ -16,7 +16,7 @@ const FeatureBoxes = () => (
     <div className='container'>
       <div className='row'>
         <div className='col'>
-          <FeatureBox icon={faTruck} active>
+          <FeatureBox icon={faTruck}>
             <h5>Free shipping</h5>
             <p>All orders</p>
           </FeatureBox>


### PR DESCRIPTION
Cześć,
Chodzi o elementy "Free shipping", etc.

Usunąłem `active` wpisany na sztywno w pierwszym elemencie, zmieniłem elementy w linki oraz dodałem style zdefiniowane w `settings.scss` na `:hover`.
+ W pliku `FeatureBox.module.scss` był zostawiony samotny element `p`. Nie wiedziałem czy specjalnie ktoś go tam zostawił z myślą o czymś konkretnym czy nie, więc tylko zakomentowałem, żeby ESLint nie zgłaszał błędu.