### PR TITLE
change ProductBox import from container

### DIFF
--- a/src/components/common/HotDealsProductBox/HotDealsProductBox.js
+++ b/src/components/common/HotDealsProductBox/HotDealsProductBox.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
-import ProductBox from '../ProductBox/ProductBox';
+import ProductBox from '../ProductBox/ProductBoxContainer';
 import Timer from '../Timer/Timer';
 
 import styles from './HotDealsProductBox.module.scss';


### PR DESCRIPTION
Kliknięcie na ikonę gwiazdki lub strzałek w sekcji 'HOT DEALS' wysypywało stronę stronę. Być może wystarczyło zmienić na import z containera?